### PR TITLE
Update to latest caniuse-lite

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -902,9 +902,9 @@
 			}
 		},
 		"node_modules/caniuse-lite": {
-			"version": "1.0.30001383",
-			"resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001383.tgz",
-			"integrity": "sha512-swMpEoTp5vDoGBZsYZX7L7nXHe6dsHxi9o6/LKf/f0LukVtnrxly5GVb/fWdCDTqi/yw6Km6tiJ0pmBacm0gbg==",
+			"version": "1.0.30001620",
+			"resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001620.tgz",
+			"integrity": "sha512-WJvYsOjd1/BYUY6SNGUosK9DUidBPDTnOARHp3fSmFO1ekdxaY6nKRttEVrfMmYi80ctS0kz1wiWmm14fVc3ew==",
 			"dev": true,
 			"funding": [
 				{
@@ -914,6 +914,10 @@
 				{
 					"type": "tidelift",
 					"url": "https://tidelift.com/funding/github/npm/caniuse-lite"
+				},
+				{
+					"type": "github",
+					"url": "https://github.com/sponsors/ai"
 				}
 			]
 		},
@@ -4781,9 +4785,9 @@
 			"dev": true
 		},
 		"caniuse-lite": {
-			"version": "1.0.30001383",
-			"resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001383.tgz",
-			"integrity": "sha512-swMpEoTp5vDoGBZsYZX7L7nXHe6dsHxi9o6/LKf/f0LukVtnrxly5GVb/fWdCDTqi/yw6Km6tiJ0pmBacm0gbg==",
+			"version": "1.0.30001620",
+			"resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001620.tgz",
+			"integrity": "sha512-WJvYsOjd1/BYUY6SNGUosK9DUidBPDTnOARHp3fSmFO1ekdxaY6nKRttEVrfMmYi80ctS0kz1wiWmm14fVc3ew==",
 			"dev": true
 		},
 		"chalk": {


### PR DESCRIPTION
Following reminder message, directed to explanation here: https://github.com/browserslist/update-db#readme

Ran command npx update-browserslist-db@latest

Message is now gone, latest library included in package-lock.json.

Probably not the most important update, but it is nice when you run things and there are no warnings or reminder messages.